### PR TITLE
Add getBlockchainInfo to commands.js

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -15,6 +15,7 @@ module.exports = {
   getBalance: 'getbalance',
   getBestBlockHash: 'getbestblockhash', // litecoind v0.8.6.1+
   getBlock: 'getblock',
+  getBlockchainInfo: 'getblockchaininfo',
   getBlockCount: 'getblockcount',
   getBlockHash: 'getblockhash',
   getBlockTemplate: 'getblocktemplate',


### PR DESCRIPTION
Adds `getBlockchainInfo` to `commands.js`.

Maps said command to `getblockchaininfo`.